### PR TITLE
Add support for PowerResource()

### DIFF
--- a/src/aml_opcodes.h
+++ b/src/aml_opcodes.h
@@ -85,6 +85,7 @@
 #define FIELD				0x81
 #define DEVICE				0x82
 #define PROCESSOR			0x83
+#define POWER				0x84
 #define THERMALZONE			0x85
 #define INDEXFIELD			0x86	// ACPI spec v5.0 section 19.5.60
 

--- a/src/lai.h
+++ b/src/lai.h
@@ -30,6 +30,7 @@
 #define ACPI_NAMESPACE_PROCESSOR	9
 #define ACPI_NAMESPACE_BUFFER_FIELD	10
 #define ACPI_NAMESPACE_THERMALZONE	11
+#define ACPI_NAMESPACE_POWER		12
 
 #define ACPI_INTEGER			1
 #define ACPI_STRING			2
@@ -349,6 +350,7 @@ size_t acpins_create_mutex(void *);
 size_t acpins_create_indexfield(void *);
 size_t acpins_create_package(acpi_object_t *, void *);
 size_t acpins_create_processor(void *);
+size_t acpins_create_power(void *);
 size_t acpins_create_bytefield(void *);
 size_t acpins_create_wordfield(void *);
 size_t acpins_create_dwordfield(void *);

--- a/src/ns.c
+++ b/src/ns.c
@@ -297,6 +297,9 @@ void acpins_register_scope(uint8_t *data, size_t size)
 			case PROCESSOR:
 				count += acpins_create_processor(&data[count]);
 				break;
+			case POWER:
+				count += acpins_create_power(&data[count]);
+				break;
 
 			default:
 				acpi_panic("acpi: undefined opcode, sequence: %xb %xb %xb %xb\n", data[count], data[count+1], data[count+2], data[count+3]);
@@ -1035,6 +1038,28 @@ size_t acpins_create_processor(void *data)
 	acpi_namespace[acpi_namespace_entries].cpu_id = processor[0];
 
 	//acpi_printf("acpi: processor %s ACPI ID %d\n", acpi_namespace[acpi_namespace_entries].path, acpi_namespace[acpi_namespace_entries].cpu_id);
+
+	acpins_increment_namespace();
+
+	return size + 2;
+}
+
+// acpins_create_power(): Creates a Power object in the namespace
+// Param:	void *data - pointer to data
+// Return:	size_t - total size in bytes, for skipping
+
+size_t acpins_create_power(void *data)
+{
+	uint8_t *power = (uint8_t*)data;
+	power += 2;			// skip over POWER_OP
+
+	size_t pkgsize, size;
+	pkgsize = acpi_parse_pkgsize(power, &size);
+	power += pkgsize;
+
+	acpi_namespace[acpi_namespace_entries].type = ACPI_NAMESPACE_POWER;
+	size_t name_size = acpins_resolve_path(acpi_namespace[acpi_namespace_entries].path, power);
+	power += name_size;
 
 	acpins_increment_namespace();
 


### PR DESCRIPTION
My BIOS seems to have these:

  2CD5: 5B 84 2E 55 52 50 31 01 00 00
        PowerResource (URP1, 0x01, 0x0000) {

Recognize them.