### PR TITLE
Avoid using uninitialized memory

### DIFF
--- a/src/exec.c
+++ b/src/exec.c
@@ -329,6 +329,7 @@ size_t acpi_methodinvoke(void *data, acpi_state_t *old_state, acpi_object_t *met
 
 	// determine the name of the method
 	acpi_state_t *state = acpi_malloc(sizeof(acpi_state_t));
+	acpi_memset(state, 0, sizeof(acpi_state_t));
 	size_t name_size = acpins_resolve_path(state->name, methodinvokation);
 	return_size += name_size;
 	methodinvokation += name_size;

--- a/src/ns.c
+++ b/src/ns.c
@@ -114,6 +114,7 @@ void acpins_increment_namespace()
 	acpi_namespace_entries++;
 	if((acpi_namespace_entries % ACPI_MAX_NAMESPACE_ENTRIES) == 0)
 		acpi_namespace = acpi_realloc(acpi_namespace, (acpi_namespace_entries + ACPI_MAX_NAMESPACE_ENTRIES + 1) * sizeof(acpi_handle_t));
+	acpi_memset(&acpi_namespace[acpi_namespace_entries], 0, sizeof(acpi_handle_t));
 }
 
 // acpi_create_namespace(): Initializes the AML interpreter and creates the ACPI namespace


### PR DESCRIPTION
When acpi_malloc() and acpi_realloc() are implemented analogously to (or
by the means of) libc malloc(3) and realloc(3), the contents of the
returned memory are not defined.

Zero the memory out in two spots valgrind complains about.